### PR TITLE
Envio do banco de dados com o client

### DIFF
--- a/Desafio/docker-compose.yml
+++ b/Desafio/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '3.4'
 
+volumes:
+  vol-db-desafio: 
+    external: true
+
 services:
 #PHP Service
   php74:
@@ -29,6 +33,32 @@ services:
       - bubble
     depends_on:
       - php74
+
+#Mysql Service
+  db:
+    container_name: desafio_mysql
+    restart: always
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+    ports:
+      - "3306:3306" 
+    volumes:
+      - vol-db-desafio:/var/lib/mysql   
+    image: mysql:8.0
+    networks:
+      - bubble
+
+#Phpmyadmin Service
+  app:
+    container_name: desafio_phpmyadmin
+    restart: always
+    links:
+      - db
+    ports:
+      - 81:80
+    image: phpmyadmin:5.1
+    networks:
+      - bubble
 
 networks:
   bubble:

--- a/Desafio/docker/web/Dockerfile
+++ b/Desafio/docker/web/Dockerfile
@@ -27,6 +27,9 @@ RUN apk add --no-cache $PHPIZE_DEPS \
     && docker-php-ext-install mysqli pdo pdo_mysql bcmath sockets
  
 # Docker non-root-user
+## definindo variáveis de ambiente
+## ARG definindo o valor no momento da construção da imagem
+## ENV recebendo o valor em tempo de execução
 ARG PUID=1000
 ENV PUID 1000
 ARG PGID=1000


### PR DESCRIPTION
-  Adicionado os containers `desafio_mysql` e `desafio_phpmyadmin` no docker compose. 
- Foi feita a conexão do laravel com o banco de dados.
- O banco foi testado com `php artisan migrate`, para ter certeza de que a conexão estava operante.